### PR TITLE
Modify audio extraction script for CLI use

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ pip install moviepy imageio[ffmpeg]
 
 ### Usage
 
-Run the script:
+Run the script, passing the path to a video file:
 
 ```bash
-python extract_audio.py
+python extract_audio.py /path/to/video.mp4
 ```
 
-A file selection dialog will appear. Choose a supported video file (`.mp4`, `.mov`, `.avi`, `.mkv`, `.webm`, `.flv`). The audio track will be saved as an MP3 file in the same directory as the selected video.
+The audio track will be saved as an MP3 file in the same directory as the provided video. On systems without a graphical interface you can run the script with `xvfb-run` if needed:
+
+```bash
+xvfb-run python extract_audio.py /path/to/video.mp4
+```

--- a/extract_audio.py
+++ b/extract_audio.py
@@ -1,23 +1,23 @@
 import os
-import tkinter as tk
-from tkinter import filedialog
+import argparse
 from moviepy.editor import VideoFileClip
 
-def select_and_extract():
-    root = tk.Tk()
-    root.withdraw()
-    video_path = filedialog.askopenfilename(
-        title="Select Video File",
-        filetypes=[("Video files", "*.mp4 *.mov *.avi *.mkv *.webm *.flv")]
-    )
-    if not video_path:
-        print("No file selected.")
-        return
+def extract_audio(video_path: str):
+    if not os.path.exists(video_path):
+        raise FileNotFoundError(f"File not found: {video_path}")
 
     output_path = os.path.splitext(video_path)[0] + ".mp3"
     with VideoFileClip(video_path) as clip:
+        if clip.audio is None:
+            raise ValueError("The provided video has no audio track")
         clip.audio.write_audiofile(output_path)
     print(f"Audio saved to {output_path}")
 
+def main():
+    parser = argparse.ArgumentParser(description="Extract audio from a video file")
+    parser.add_argument("video", help="Path to the video file")
+    args = parser.parse_args()
+    extract_audio(args.video)
+
 if __name__ == "__main__":
-    select_and_extract()
+    main()


### PR DESCRIPTION
## Summary
- convert extract_audio.py to use command-line arguments instead of Tkinter
- update README with new usage instructions and mention `xvfb-run`

## Testing
- `python extract_audio.py sample_with_audio.mp4`

------
https://chatgpt.com/codex/tasks/task_e_683ff3227d708328a488d964e9a4b522